### PR TITLE
Update KeycloakWebGuardServiceProvider.php

### DIFF
--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -90,19 +90,19 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
         $router = $this->app->make('router');
 
         if (! empty($options['login'])) {
-            $router->middleware(StartSession::class)->get($options['login'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@login')->name('keycloak.login');
+            $router->middleware('web')->get($options['login'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@login')->name('keycloak.login');
         }
 
         if (! empty($options['logout'])) {
-            $router->middleware(StartSession::class)->get($options['logout'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@logout')->name('keycloak.logout');
+            $router->middleware('web')->get($options['logout'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@logout')->name('keycloak.logout');
         }
 
         if (! empty($options['register'])) {
-            $router->middleware(StartSession::class)->get($options['register'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@register')->name('keycloak.register');
+            $router->middleware('web')->get($options['register'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@register')->name('keycloak.register');
         }
 
         if (! empty($options['callback'])) {
-            $router->middleware(StartSession::class)->get($options['callback'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@callback')->name('keycloak.callback');
+            $router->middleware('web')->get($options['callback'], 'Vizir\KeycloakWebGuard\Controllers\AuthController@callback')->name('keycloak.callback');
         }
     }
 }


### PR DESCRIPTION
Session which contains keycloak token can not be retreived in keycloakWeb middleware becuase of missing EncryptCookies and AddQueuedCookiesToResponse middlewares on routes defined in KeycloakWebGuardServiceProvider.php