### PR TITLE
Sometimes Auth::user provide a boolean

### DIFF
--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -56,7 +56,10 @@ class KeycloakWebGuard implements Guard
      */
     public function user()
     {
-        return $this->user ?: $this->authenticate();
+        if(!$this->user) {
+            $this->authenticate();
+        }
+        return $this->user;
     }
 
     /**

--- a/src/Auth/Guard/KeycloakWebGuard.php
+++ b/src/Auth/Guard/KeycloakWebGuard.php
@@ -56,7 +56,7 @@ class KeycloakWebGuard implements Guard
      */
     public function user()
     {
-        if(!$this->user) {
+        if(! $this->user) {
             $this->authenticate();
         }
         return $this->user;


### PR DESCRIPTION
This is due to authenticate() method wich return a boolean. 
If use of ternary operator you can get a user (if exists) or bool (result of authenticate() method)