### PR TITLE
Adding Dynamic Guzzle Config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,20 @@ class EncryptCookies extends Middleware
 
 If your client is not public, you should provide a `KEYCLOAK_CLIENT_SECRET` on your `.env`.
 
+### How can I override the default Guzzle options?
+
+In some use cases you may need to override the default Guzzle options - likely either to disable SSL verification or to set a Proxy to route all requests through.
+
+Every [http://docs.guzzlephp.org/en/stable/request-options.html](Guzzle Request Option) is supported and is passed directly to the Guzzle Client instance.
+
+Just add the options you would like as an array to the `keycloak-web.php` config file.
+
+```
+'guzzle_options' => [
+    'verify' => false
+]
+```
+
 ## Developers
 
 * Mário Valney [@mariovalney](https://twitter.com/mariovalney)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ We can cache the OpenId Configuration: it's a list of endpoints we require to Ke
 
 If you activate it, *remember to flush the cache* when change the realm or url.
 
+Just add the options you would like as an array to the" to "Just add the options you would like to guzzle_options array on keycloak-web.php config file. For example:
+
 ## Laravel Auth
 
 You should add Keycloak Web guard to your `config/auth.php`.
@@ -234,7 +236,7 @@ In some use cases you may need to override the default Guzzle options - likely e
 
 Every [http://docs.guzzlephp.org/en/stable/request-options.html](Guzzle Request Option) is supported and is passed directly to the Guzzle Client instance.
 
-Just add the options you would like as an array to the `keycloak-web.php` config file.
+Just add the options you would like to `guzzle_options` array on `keycloak-web.php` config file. For example:
 
 ```
 'guzzle_options' => [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "guzzlehttp/guzzle": "^6.3@dev"
+        "guzzlehttp/guzzle": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/config/keycloak-web.php
+++ b/config/keycloak-web.php
@@ -65,5 +65,12 @@ return [
         'logout' => 'logout',
         'register' => 'register',
         'callback' => 'callback',
-    ]
+    ],
+
+    /**
+    * GuzzleHttp Client options
+    *
+    * @link http://docs.guzzlephp.org/en/stable/request-options.html
+    */
+   'guzzle_options' => [],
 ];

--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Vizir\KeycloakWebGuard;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
@@ -64,9 +62,6 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
         ]);
 
         $this->app['router']->aliasMiddleware('keycloak-web-can', KeycloakCan::class);
-
-        // Interfaces
-        $this->app->bind(ClientInterface::class, Client::class);
     }
 
     /**

--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -2,7 +2,7 @@
 
 namespace Vizir\KeycloakWebGuard\Services;
 
-use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -79,10 +79,9 @@ class KeycloakService
      * You can extend this service setting protected variables before call
      * parent constructor to comunicate with Keycloak smoothly.
      *
-     * @param ClientInterface $client
      * @return void
      */
-    public function __construct(ClientInterface $client)
+    public function __construct()
     {
         if (is_null($this->baseUrl)) {
             $this->baseUrl = trim(Config::get('keycloak-web.base_url'), '/');
@@ -112,7 +111,8 @@ class KeycloakService
             $this->redirectLogout = Config::get('keycloak-web.redirect_logout');
         }
 
-        $this->httpClient = $client;
+        $this->httpClient = new Client(Config::get('keycloak-web.guzzle_options', []));
+
         $this->openid = $this->getOpenIdConfiguration();
     }
 


### PR DESCRIPTION
Adds loading a dynamic Guzzle config object from your Keycloak Web config.

Primary use case for this is if you're doing local development and need to disable SSL verification.

Also a light refactor of how Guzzle is imported and bumping to latest stable Guzzle