### PR TITLE
Re-enable DI for KeycloakService

### DIFF
--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Vizir\KeycloakWebGuard;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
@@ -62,6 +64,12 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
         ]);
 
         $this->app['router']->aliasMiddleware('keycloak-web-can', KeycloakCan::class);
+
+        $this->app->when(KeycloakService::class)
+            ->needs(ClientInterface::class)
+            ->give(static function() {
+                new Client(Config::get('keycloak-web.guzzle_options', []));
+            });
     }
 
     /**

--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -2,7 +2,7 @@
 
 namespace Vizir\KeycloakWebGuard\Services;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -79,9 +79,10 @@ class KeycloakService
      * You can extend this service setting protected variables before call
      * parent constructor to comunicate with Keycloak smoothly.
      *
+     * @param ClientInterface $client
      * @return void
      */
-    public function __construct()
+    public function __construct(ClientInterface $client)
     {
         if (is_null($this->baseUrl)) {
             $this->baseUrl = trim(Config::get('keycloak-web.base_url'), '/');
@@ -111,8 +112,7 @@ class KeycloakService
             $this->redirectLogout = Config::get('keycloak-web.redirect_logout');
         }
 
-        $this->httpClient = new Client(Config::get('keycloak-web.guzzle_options', []));
-
+        $this->httpClient = $client;
         $this->openid = $this->getOpenIdConfiguration();
     }
 


### PR DESCRIPTION
I was using container to pass my own client implementation with custom settings.

This commit https://github.com/Vizir/laravel-keycloak-web-guard/commit/30f09ce92b1b6141a7c001b39919f8bf10915ff0 breaks because we no more use DI. The idea behind is very good, but using DI will be much cleaner. Allows passing mocked implementation for testing...

This PR re-enable dependencies injection, without breaking changes.