### PR TITLE
Revamping openid attribute to getOpenidValue

### DIFF
--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -4,7 +4,6 @@ namespace Vizir\KeycloakWebGuard\Services;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;

--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -113,7 +113,6 @@ class KeycloakService
         }
 
         $this->httpClient = $client;
-        $this->openid = $this->getOpenIdConfiguration();
     }
 
     /**
@@ -125,7 +124,7 @@ class KeycloakService
      */
     public function getLoginUrl()
     {
-        $url = $this->openid['authorization_endpoint'];
+        $url = $this->getOpenIdValue('authorization_endpoint');
         $params = [
             'scope' => 'openid',
             'client_id' => $this->clientId,
@@ -143,7 +142,7 @@ class KeycloakService
      */
     public function getLogoutUrl()
     {
-        $url = $this->openid['end_session_endpoint'];
+        $url = $this->getOpenIdValue('end_session_endpoint');
 
         if (empty($this->redirectLogout)) {
             $this->redirectLogout = url('/');
@@ -172,7 +171,7 @@ class KeycloakService
      */
     public function getAccessToken($code)
     {
-        $url = $this->openid['token_endpoint'];
+        $url = $this->getOpenIdValue('token_endpoint');
         $params = [
             'code' => $code,
             'client_id' => $this->clientId,
@@ -212,7 +211,7 @@ class KeycloakService
             return [];
         }
 
-        $url = $this->openid['token_endpoint'];
+        $url = $this->getOpenIdValue('token_endpoint');
         $params = [
             'client_id' => $this->clientId,
             'grant_type' => 'refresh_token',
@@ -248,7 +247,7 @@ class KeycloakService
      */
     public function invalidateRefreshToken($refreshToken)
     {
-        $url = $this->openid['end_session_endpoint'];
+        $url = $this->getOpenIdValue('end_session_endpoint');
         $params = [
             'client_id' => $this->clientId,
             'refresh_token' => $refreshToken,
@@ -282,7 +281,7 @@ class KeycloakService
             return [];
         }
 
-        $url = $this->openid['userinfo_endpoint'];
+        $url = $this->getOpenIdValue('userinfo_endpoint');
         $headers = [
             'Authorization' => 'Bearer ' . $credentials['access_token'],
             'Accept' => 'application/json',
@@ -400,6 +399,21 @@ class KeycloakService
         $query = array_merge($query, $params);
 
         return $url . '?' . Arr::query($query);
+    }
+
+    /**
+     * Return a value from the Open ID Configuration
+     * 
+     * @param  string $key
+     * @return string
+     */
+    protected function getOpenIdValue($key)
+    {
+        if (!$this->openid) {
+            $this->openid = $this->getOpenIdConfiguration();
+        }
+
+        return $this->openid[$key];
     }
 
     /**

--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Vizir\KeycloakWebGuard\Auth\Guard\KeycloakWebGuard;
+use Illuminate\Support\Arr;
 
 class KeycloakService
 {
@@ -413,7 +414,7 @@ class KeycloakService
             $this->openid = $this->getOpenIdConfiguration();
         }
 
-        return $this->openid[$key];
+        return Arr::get($this->openid, $key);
     }
 
     /**

--- a/src/Services/KeycloakService.php
+++ b/src/Services/KeycloakService.php
@@ -4,12 +4,12 @@ namespace Vizir\KeycloakWebGuard\Services;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Vizir\KeycloakWebGuard\Auth\Guard\KeycloakWebGuard;
-use Illuminate\Support\Arr;
 
 class KeycloakService
 {


### PR DESCRIPTION
Right now anytime Laravel boots its running the `getOpenIdConfiguration()` call. This is generally unnecessary and causes some issues with things like Unit and Integration tests where Keycloak doesn't exist and Auth is being mocked.
