### PR TITLE
[wip] feat: keycloak sync command

### DIFF
--- a/config/keycloak-web.php
+++ b/config/keycloak-web.php
@@ -73,4 +73,12 @@ return [
     * @link http://docs.guzzlephp.org/en/stable/request-options.html
     */
    'guzzle_options' => [],
+
+   /**
+    * Admin Credentials
+    */
+    'admin' => [
+        'username' => env('KEYCLOAK_ADMIN_USERNAME', ''),
+        'password' => env('KEYCLOAK_ADMIN_PASSWORD', ''),
+    ]
 ];

--- a/src/Commands/KeycloakUserSync.php
+++ b/src/Commands/KeycloakUserSync.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Vizir\KeycloakWebGuard\Commands;
+
+use DateTime;
+use DateTimeZone;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Vizir\KeycloakWebGuard\Services\KeycloakService;
+
+class KeycloakUserSync extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'keycloak:sync';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Syncronization of the Keycloak Users to local database';
+
+    /* @var KeycloakService */
+    protected $keycloakService;
+
+    /**
+     * Command Constructor
+     */
+    public function __construct(KeycloakService $keycloakService) {
+        parent::__construct();
+        $this->keycloakService = $keycloakService;
+    }
+    
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        DB::beginTransaction();
+        $now = new DateTime('now', new DateTimeZone(config('app.timezone')));
+        foreach($this->keycloakService->getUsers(config('keycloak-web.admin.username'), config('keycloak-web.admin.password')) as $keyCloakUser) {
+            $data = [
+                'keycloak_id' => $keyCloakUser['id'],
+                'email' => $keyCloakUser['email'],
+                'email_verified_at' => $keyCloakUser['emailVerified'] ? $now : null,
+                'name' => join(' ', array_filter([$keyCloakUser['firstName'], $keyCloakUser['lastName']])),
+                'created_at' => DateTime::createFromFormat('U', intval($keyCloakUser['createdTimestamp'] / 1000)),
+                'updated_at' => $now
+            ];
+
+            DB::table('users')->updateOrInsert(['keycloak_id' => $keyCloakUser['id']], $data);
+        }
+        DB::commit();
+
+        return 0;
+    }
+
+}

--- a/src/KeycloakWebGuardServiceProvider.php
+++ b/src/KeycloakWebGuardServiceProvider.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Vizir\KeycloakWebGuard\Auth\Guard\KeycloakWebGuard;
 use Vizir\KeycloakWebGuard\Auth\KeycloakWebUserProvider;
+use Vizir\KeycloakWebGuard\Commands\KeycloakUserSync;
 use Vizir\KeycloakWebGuard\Middleware\KeycloakAuthenticated;
 use Vizir\KeycloakWebGuard\Middleware\KeycloakCan;
-use Vizir\KeycloakWebGuard\Models\KeycloakUser;
 use Vizir\KeycloakWebGuard\Services\KeycloakService;
 
 class KeycloakWebGuardServiceProvider extends ServiceProvider
@@ -30,6 +30,9 @@ class KeycloakWebGuardServiceProvider extends ServiceProvider
 
         $this->publishes([$config => config_path('keycloak-web.php')], 'config');
         $this->mergeConfigFrom($config, 'keycloak-web');
+        $this->commands([
+            KeycloakUserSync::class
+        ]);
 
         // User Provider
         Auth::provider('keycloak-users', function($app, array $config) {


### PR DESCRIPTION
### how works:
i used keycloak admin api to retrieve all users and sync on the local database.

### setup:
after setup environment configs, add a new column on users table
```
$table->uuid('keycloak_id');
```
and finally run `php artisan keycloak:sync`

### changelog:
```
added:
- environment config: KEYCLOAK_ADMIN_USERNAME, KEYCLOAK_ADMIN_PASSWORD
- command keycloak:sync

changes:
- cleanup unused dependencies

known issues:
- admin api returns only 100 users, need to implement GET /{realm}/users/count.
```