### PR TITLE
token expired check fix

### DIFF
--- a/src/Auth/KeycloakAccessToken.php
+++ b/src/Auth/KeycloakAccessToken.php
@@ -92,7 +92,7 @@ class KeycloakAccessToken
         $exp = $this->parseAccessToken();
         $exp = $exp['exp'] ?? '';
 
-        return time() < (int) $exp;
+        return time() >= (int) $exp;
     }
 
     /**


### PR DESCRIPTION
The checking to know if the token has expired was upside down. The hasExpired function was returning true if $exp was greater than time(). The hasExpired function only should returning true when the $exp is less than or equal time(), that is, when the token has expired.