### PR TITLE
Rename "Sutdio" to "Studio"

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,6 @@ Just add the options you would like to `guzzle_options` array on `keycloak-web.p
 ## Developers
 
 * Mário Valney [@mariovalney](https://twitter.com/mariovalney)
-* [Vizir Software Sutdio](https://vizir.com.br)
+* [Vizir Software Studio](https://vizir.com.br)
 
 With contributors on GitHub :heart:


### PR DESCRIPTION
Hi @mariovalney, I saw in README there's a "Sutdio" word. I hope it's a typo and if it is then here's the PR to fix the typo. :)